### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ env:
 
 jobs:
   build:
+    permissions:
+      contents: read
     name: Build ${{ matrix.os }} - ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -57,6 +59,8 @@ jobs:
             target/rustcan-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
 
   release:
+    permissions:
+      contents: write
     name: Create Release
     needs: build
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/cryptexctl/rustcan/security/code-scanning/2](https://github.com/cryptexctl/rustcan/security/code-scanning/2)

To fix the issue, we will add a `permissions` block to the workflow to explicitly define the minimal permissions required for each job. For the `build` job, only `contents: read` is needed to check out the repository. For the `release` job, `contents: write` is required to create a release and upload assets. This ensures that the `GITHUB_TOKEN` has only the necessary permissions for each job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
