### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -60,6 +63,9 @@ jobs:
     name: Create Release
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
Potential fix for [https://github.com/cryptexctl/rustcan/security/code-scanning/1](https://github.com/cryptexctl/rustcan/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the workflow. At the workflow level, we will set `contents: read` as the default permission, which is sufficient for most steps. For jobs that require additional permissions, such as the `release` job, we will override the default permissions and explicitly grant the necessary write permissions (`contents: write` and `packages: write`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
